### PR TITLE
Add QA-focused automated tests for fraud detection pipeline

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,125 @@
+import math
+import sys
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from utils.data_processor import DataProcessor
+from utils.explanations import ExplanationEngine
+from utils.fraud_engine import FraudEngine
+from utils.ml_models import MLModelManager
+
+
+@pytest.fixture(scope="session")
+def data_processor() -> DataProcessor:
+    return DataProcessor()
+
+
+@pytest.fixture(scope="session")
+def synthetic_raw_claims() -> Tuple[pd.DataFrame, dict]:
+    rng = np.random.default_rng(2024)
+    n_rows = 240
+
+    base_amounts = rng.integers(5000, 120000, size=n_rows)
+    # Inject high-risk scenarios in the first 40 rows to guarantee positives
+    high_risk_amounts = rng.integers(180000, 320000, size=40)
+    base_amounts[:40] = high_risk_amounts
+
+    hours = rng.integers(0, 24, size=n_rows)
+    hours[:20] = rng.choice([1, 2, 3, 23], size=20)  # suspicious hours
+
+    witnesses = rng.integers(0, 4, size=n_rows)
+    witnesses[:30] = 0  # no witnesses for many high-risk rows
+
+    severities = rng.choice(
+        ["Minor Damage", "Major Damage", "Total Loss"], size=n_rows, p=[0.45, 0.35, 0.20]
+    )
+    severities[:30] = rng.choice(["Major Damage", "Total Loss"], size=30)
+
+    incident_types = rng.choice(
+        [
+            "Single Vehicle Collision",
+            "Multi-vehicle Collision",
+            "Parked Car",
+            "Vehicle Theft",
+        ],
+        size=n_rows,
+    )
+    incident_types[:20] = "Vehicle Theft"
+
+    raw_df = pd.DataFrame(
+        {
+            "ClaimNumber": [f"CLM{i:04d}" for i in range(n_rows)],
+            "ClaimAmount": base_amounts,
+            "HourOfDay": hours,
+            "DriverAge": rng.integers(21, 70, size=n_rows),
+            "IncidentType": incident_types,
+            "IncidentSeverity": severities,
+            "WitnessCount": witnesses,
+            "PoliceReport": rng.choice(["YES", "NO", "UNKNOWN"], size=n_rows, p=[0.6, 0.3, 0.1]),
+        }
+    )
+
+    column_mapping = {
+        "claim_id": "ClaimNumber",
+        "total_claim_amount": "ClaimAmount",
+        "incident_hour_of_the_day": "HourOfDay",
+        "age": "DriverAge",
+        "incident_type": "IncidentType",
+        "incident_severity": "IncidentSeverity",
+        "witnesses": "WitnessCount",
+        "police_report_available": "PoliceReport",
+    }
+
+    return raw_df, column_mapping
+
+
+@pytest.fixture(scope="session")
+def processed_claims(data_processor: DataProcessor, synthetic_raw_claims):
+    raw_df, column_mapping = synthetic_raw_claims
+    processed_df = data_processor.prepare_data(raw_df, column_mapping)
+    return processed_df
+
+
+@pytest.fixture(scope="session")
+def training_dataframe(processed_claims):
+    fraud_engine = FraudEngine()
+    explanation_engine = ExplanationEngine()
+
+    rule_results = [
+        fraud_engine.analyze_single_claim(row._asdict() if hasattr(row, "_asdict") else row.to_dict())
+        for _, row in processed_claims.iterrows()
+    ]
+
+    rule_df = pd.DataFrame(rule_results)
+    explained_df = explanation_engine.add_explanations(rule_df)
+
+    training_df = processed_claims.reset_index(drop=True).copy()
+    training_df["risk_score"] = explained_df["risk_score"].astype(float)
+    training_df["triggered_rules"] = explained_df["triggered_rules"].fillna("")
+
+    return training_df
+
+
+@pytest.fixture(scope="session")
+def trained_manager(training_dataframe):
+    manager = MLModelManager()
+    trained = manager.train_models(training_dataframe)
+    if not trained:
+        raise RuntimeError("Failed to train ML models for test fixtures")
+    return manager
+
+
+@pytest.fixture(scope="session")
+def large_inference_frame(training_dataframe):
+    multiplier = math.ceil(5000 / len(training_dataframe))
+    expanded_df = pd.concat([training_dataframe] * multiplier, ignore_index=True)
+    return expanded_df.head(5000)

--- a/tests/test_acceptance_and_benchmark.py
+++ b/tests/test_acceptance_and_benchmark.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.mark.skip(reason="User Acceptance Testing requires coordinated human evaluation and feedback capture.")
+def test_user_acceptance_manual_verification():
+    """Placeholder for manual UAT involving claims officers and IT staff."""
+    pass
+
+
+@pytest.mark.skip(reason="Benchmark testing depends on external baseline performance data.")
+def test_benchmark_against_manual_process():
+    """Placeholder ensuring comparative evaluation is tracked outside automated suite."""
+    pass

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -1,0 +1,55 @@
+import pandas as pd
+import pytest
+
+from utils.data_processor import DataProcessor
+
+
+def test_prepare_data_handles_missing_and_engineers_features(data_processor):
+    raw_df = pd.DataFrame(
+        {
+            "ClaimNumber": ["A1", "A2"],
+            "ClaimAmount": [10000, 250000],
+            "HourOfDay": [8, 2],
+            "DriverAge": [30, 22],
+            "WitnessCount": [1, 0],
+        }
+    )
+
+    mapping = {
+        "claim_id": "ClaimNumber",
+        "total_claim_amount": "ClaimAmount",
+        "incident_hour_of_the_day": "HourOfDay",
+        "age": "DriverAge",
+        "witnesses": "WitnessCount",
+    }
+
+    processed = data_processor.prepare_data(raw_df, mapping)
+
+    # Required engineered features should exist
+    expected_columns = {
+        "log_claim_amount",
+        "amount_category",
+        "is_round_amount",
+        "hour_category",
+        "unusual_hour",
+    }
+    assert expected_columns.issubset(set(processed.columns))
+
+    # Missing optional columns get defaults without raising errors
+    assert processed.loc[0, "age"] == 30
+    assert processed.loc[1, "unusual_hour"] in (0, 1)
+
+
+def test_prepare_data_raises_without_amount():
+    processor = DataProcessor()
+    raw_df = pd.DataFrame({"ClaimNumber": ["A1"], "HourOfDay": [12]})
+
+    mapping = {
+        "claim_id": "ClaimNumber",
+        "incident_hour_of_the_day": "HourOfDay",
+    }
+
+    with pytest.raises(Exception) as exc:
+        processor.prepare_data(raw_df, mapping)
+
+    assert "Required column" in str(exc.value)

--- a/tests/test_feature_explainer.py
+++ b/tests/test_feature_explainer.py
@@ -1,0 +1,21 @@
+from utils.feature_explainer import FeatureExplainer
+
+
+def test_feature_explainer_generates_contributions(trained_manager, training_dataframe):
+    explainer = FeatureExplainer()
+    explainer.fit(trained_manager, training_dataframe[trained_manager.feature_columns])
+
+    sample_row = training_dataframe.iloc[0].to_dict()
+    probability = trained_manager.predict_single(training_dataframe.iloc[0])
+    explanation = explainer.explain_prediction(sample_row, probability)
+
+    assert "contributions" in explanation
+    assert explanation["contributions"]  # non-empty
+    top_positive = explanation["top_positive"]
+    top_negative = explanation["top_negative"]
+
+    # Ensure formatted output is human readable
+    if top_positive:
+        assert all("feature" in item and "contribution" in item for item in top_positive)
+    if top_negative:
+        assert all("feature" in item and "contribution" in item for item in top_negative)

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from utils.explanations import ExplanationEngine
+from utils.fraud_engine import FraudEngine
+
+
+def test_end_to_end_pipeline(data_processor, synthetic_raw_claims, trained_manager):
+    raw_df, column_mapping = synthetic_raw_claims
+    processed_df = data_processor.prepare_data(raw_df, column_mapping)
+
+    fraud_engine = FraudEngine()
+    explanation_engine = ExplanationEngine()
+
+    rule_results = [
+        fraud_engine.analyze_single_claim(row.to_dict())
+        for _, row in processed_df.iterrows()
+    ]
+
+    rule_df = pd.DataFrame(rule_results)
+    explained_df = explanation_engine.add_explanations(rule_df)
+
+    combined_df = processed_df.reset_index(drop=True).copy()
+    combined_df["risk_score"] = explained_df["risk_score"].astype(float)
+    combined_df["triggered_rules"] = explained_df["triggered_rules"].fillna("")
+
+    predictions = trained_manager.predict_batch(combined_df.head(50))
+
+    assert len(predictions) == 50
+    assert (predictions >= 0).all() and (predictions <= 1).all()
+    assert combined_df["triggered_rules"].str.len().gt(0).mean() > 0.5

--- a/tests/test_ml_models.py
+++ b/tests/test_ml_models.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+
+def test_predict_batch_returns_probabilities(trained_manager, training_dataframe):
+    sample = training_dataframe.head(25)
+    predictions = trained_manager.predict_batch(sample)
+
+    assert len(predictions) == len(sample)
+    assert np.all((predictions >= 0) & (predictions <= 1))
+
+
+def test_individual_models_produce_outputs(trained_manager, training_dataframe):
+    feature_cols = trained_manager.feature_columns
+    feature_frame = training_dataframe[feature_cols]
+    scaled = trained_manager.scaler.transform(feature_frame)
+
+    lr_probs = trained_manager.logistic_model.predict_proba(scaled)[:, 1]
+    rf_probs = trained_manager.rf_model.predict_proba(scaled)[:, 1]
+
+    assert lr_probs.shape[0] == len(feature_frame)
+    assert rf_probs.shape[0] == len(feature_frame)
+    # Ensure the two models learn different decision surfaces
+    assert not np.allclose(lr_probs, rf_probs)
+
+
+def test_predict_single_consistency(trained_manager, training_dataframe):
+    row = training_dataframe.iloc[0]
+    prob_single = trained_manager.predict_single(row)
+    batch_prob = trained_manager.predict_batch(training_dataframe.head(1))[0]
+
+    assert pytest.approx(prob_single, rel=1e-6) == batch_prob

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,30 @@
+import time
+
+from utils.feature_explainer import FeatureExplainer
+
+
+PERFORMANCE_BUDGET_SECONDS = 30.0
+
+
+def test_batch_inference_under_budget(trained_manager, large_inference_frame):
+    start = time.perf_counter()
+    predictions = trained_manager.predict_batch(large_inference_frame)
+    duration = time.perf_counter() - start
+
+    assert len(predictions) == len(large_inference_frame)
+    assert duration < PERFORMANCE_BUDGET_SECONDS
+
+
+def test_shap_generation_under_budget(trained_manager, large_inference_frame):
+    explainer = FeatureExplainer()
+    explainer.fit(trained_manager, large_inference_frame[trained_manager.feature_columns])
+
+    sample_rows = large_inference_frame.head(25)
+    sample_probs = trained_manager.predict_batch(sample_rows)
+
+    start = time.perf_counter()
+    for offset, (_, row) in enumerate(sample_rows.iterrows()):
+        explainer.explain_prediction(row.to_dict(), sample_probs[offset])
+    duration = time.perf_counter() - start
+
+    assert duration < PERFORMANCE_BUDGET_SECONDS


### PR DESCRIPTION
## Summary
- add reusable pytest fixtures that synthesize claims data for deterministic QA runs
- exercise preprocessing, model inference, explainability, and pipeline integration through unit and integration tests
- capture performance budgets and manual-only acceptance/benchmark placeholders in dedicated test modules

## Testing
- pytest -q